### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Custom Join Messages is a feature-packed plugin for handling all join and quit n
     * Supports multiple different formatters to fit your needs
         * [MineDown](https://github.com/Phoenix616/MineDown)
         * [MiniMessage](https://docs.adventure.kyori.net/minimessage/index.html) ([Paper](https://papermc.io/) only)
-        * [Legacy](https://minecraft.fandom.com/wiki/Formatting_codes)
+        * [Legacy](https://minecraft.wiki/w/Formatting_codes)
     * All messages support HEX colors
     * All messages support gradients when using MineDown or MiniMessage
     * Chat messages support hover/click actions when using MineDown or MiniMessage

--- a/docs/writing-messages/formatting.rst
+++ b/docs/writing-messages/formatting.rst
@@ -46,8 +46,8 @@ It also has support for three special styles of HEX colors, being ``{#000000}``,
 .. _MineDown Syntax: https://github.com/Phoenix616/MineDown#syntax
 .. _MiniMessage: https://docs.adventure.kyori.net/minimessage/index.html
 .. _MiniMessage Syntax: https://docs.adventure.kyori.net/minimessage/format.html
-.. _Legacy: https://minecraft.fandom.com/wiki/Formatting_codes
-.. _Legacy Syntax: https://minecraft.fandom.com/wiki/Formatting_codes
+.. _Legacy: https://minecraft.wiki/w/Formatting_codes
+.. _Legacy Syntax: https://minecraft.wiki/w/Formatting_codes
 
 .. _Markdown: https://www.markdownguide.org/getting-started/#what-is-markdown
 .. _Paper: https://github.com/PaperMC/Paper

--- a/modrinth_page.md
+++ b/modrinth_page.md
@@ -37,7 +37,7 @@ Custom Join Messages is a feature-packed plugin for handling all join and quit n
     * Supports multiple different formatters to fit your needs
         * [MineDown](https://github.com/Phoenix616/MineDown)
         * [MiniMessage](https://docs.adventure.kyori.net/minimessage/index.html) ([Paper](https://papermc.io/) only)
-        * [Legacy](https://minecraft.fandom.com/wiki/Formatting_codes)
+        * [Legacy](https://minecraft.wiki/w/Formatting_codes)
     * All messages support HEX colors
     * All messages support gradients when using MineDown or MiniMessage
     * Chat messages support hover/click actions when using MineDown or MiniMessage

--- a/spigot_page.bbcode
+++ b/spigot_page.bbcode
@@ -48,7 +48,7 @@
         [LIST]
         [*] [URL='https://github.com/Phoenix616/MineDown']MineDown[/URL]
         [*] [URL='https://docs.adventure.kyori.net/minimessage/index.html']MiniMessage[/URL] ([URL='papermc.io/']Paper[/URL] only)
-        [*] [URL='https://minecraft.fandom.com/wiki/Formatting_codes']Legacy[/URL]
+        [*] [URL='https://minecraft.wiki/w/Formatting_codes']Legacy[/URL]
         [/LIST]
     [*] All messages support HEX colors
     [*] All messages support gradients when using MineDown or MiniMessage


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.