### PR TITLE
Add Phoenix compatibility support and dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
     maven("https://repo.minebench.de/") // MineDown
     maven("https://repo.papermc.io/repository/maven-public/") // MockBukkit
     maven("https://repo.sayandev.org/snapshots") // SayanVanish
+    maven("https://maven.refinedev.xyz/public-repo") // Phoenix
 }
 
 dependencies {
@@ -41,6 +42,7 @@ dependencies {
     compileOnly("net.essentialsx:EssentialsX:2.21.1") { isTransitive = false }
     compileOnly("org.sayandev:sayanvanish-api:1.6.3") { isTransitive = false }
     compileOnly("org.sayandev:sayanvanish-bukkit:1.6.3") { isTransitive = false }
+    compileOnly("xyz.refinedev.phoenix:pxAPI:1.8.6") { isTransitive = false }
 
     // Internal
     compileOnly("org.spigotmc:spigot-api:1.21.5-R0.1-SNAPSHOT")

--- a/src/main/kotlin/net/insprill/cjm/compatibility/Dependency.kt
+++ b/src/main/kotlin/net/insprill/cjm/compatibility/Dependency.kt
@@ -8,6 +8,7 @@ import net.insprill.cjm.compatibility.hook.PluginHook
 import net.insprill.cjm.compatibility.supervanish.SuperVanishHook
 import net.insprill.cjm.compatibility.vanishnopacket.VanishNoPacketHook
 import net.insprill.cjm.compatibility.velocityvanish.VelocityVanishHook
+import net.insprill.cjm.compatibility.phoenix.PhoenixHook
 import net.insprill.cjm.util.ServiceProviderUtils.getRegisteredServiceProvider
 import net.swiftzer.semver.SemVer
 import org.bukkit.Bukkit
@@ -32,6 +33,7 @@ enum class Dependency(
     VANISH_NO_PACKET("VanishNoPacket", VanishNoPacketHook::class.java),
     VAULT("Vault", null, getRegisteredServiceProvider("net.milkbowl.vault.chat.Chat")?.provider),
     VELOCITY_VANISH("VelocityVanish", VelocityVanishHook::class.java),
+    PHOENIX("Phoenix", PhoenixHook::class.java),
     ;
 
     val isEnabled get() = Bukkit.getPluginManager().isPluginEnabled(pluginName)

--- a/src/main/kotlin/net/insprill/cjm/compatibility/phoenix/PhoenixHook.kt
+++ b/src/main/kotlin/net/insprill/cjm/compatibility/phoenix/PhoenixHook.kt
@@ -1,0 +1,12 @@
+﻿package net.insprill.cjm.compatibility.phoenix
+
+import net.insprill.cjm.CustomJoinMessages
+import net.insprill.cjm.compatibility.hook.PluginHook
+
+class PhoenixHook(plugin: CustomJoinMessages) : PluginHook {
+
+    override val authHook = null
+    override val vanishHook = PhoenixVanishHook(plugin)
+    override val jailHook = null
+
+}

--- a/src/main/kotlin/net/insprill/cjm/compatibility/phoenix/PhoenixVanishHook.kt
+++ b/src/main/kotlin/net/insprill/cjm/compatibility/phoenix/PhoenixVanishHook.kt
@@ -1,0 +1,36 @@
+﻿package net.insprill.cjm.compatibility.phoenix
+
+import net.insprill.cjm.CustomJoinMessages
+import net.insprill.cjm.compatibility.hook.VanishHook
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import xyz.refinedev.phoenix.utils.events.PlayerModModeDisableEvent
+import xyz.refinedev.phoenix.utils.events.PlayerModModeEnableEvent
+
+class PhoenixVanishHook(
+    override val plugin: CustomJoinMessages,
+) : VanishHook, Listener {
+
+    private val vanishedPlayers = mutableSetOf<Player>()
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onVanish(e: PlayerModModeEnableEvent) {
+        if (e.isModMode) {
+            vanishedPlayers.add(e.player)
+            handleToggle(e.player, true)
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onUnVanish(e: PlayerModModeDisableEvent) {
+        if (!e.isModMode) {
+            vanishedPlayers.remove(e.player)
+            handleToggle(e.player, false)
+        }
+    }
+
+    override fun isVanished(player: Player): Boolean {
+        return player in vanishedPlayers
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,8 @@ softdepend:
   - VanishNoPacket
   - Vault
   - VelocityVanish
+  - Retention # Retention is the plugin loader for Phoenix
+  - Phoenix
 
 permissions:
   cjm.default:


### PR DESCRIPTION
Add Phoenix Support for vanishing.
A pretty shabby implementation given it is my first time with minecraft plugins really, but I've tested it on my server and it works.
It should be noted that due to the minimal room given in the Phoenix API, the fake message will only function if the user runs **/modmode**, not **/vanish**. (Modmode applies vanish anyway so 🤷)

Any feedback, don't hold back!!